### PR TITLE
Removed name value from FB item.

### DIFF
--- a/src/SocialFeed.php
+++ b/src/SocialFeed.php
@@ -424,8 +424,6 @@ class FacebookService extends SocialFeedService {
 		$response->link = $item->link;//"http://www.facebook.com/permalink.php?id={$user->id}&v=wall&story_fbid={$response->id}";
 		if (isset($item->message))
 			$response->text = $item->message;
-		if (isset($item->name))
-			$response->text = $item->name;
 		if (isset($item->type)) {
 			switch ($item->type) {
 				case 'photo':


### PR DESCRIPTION
Hey there! I removed the name value from Facebook item, because the message should the intended text for each Facebook post. If we don't do this, if the post have attached a media, the text can be "Timeline photo" or "Cover photo", and I don't think that this is what we want to show the users.

Hope you can make the merge as soon as possible. Thanks!
